### PR TITLE
Break VALUES and CODES with a real separator

### DIFF
--- a/R/read.px.R
+++ b/R/read.px.R
@@ -46,8 +46,8 @@ read.px <- function(filename, encoding = NULL,
     }
 
     break.clean <- function(x) {
-        x <- clean.spaces( strsplit(x, split = '\\"')[[1]] )    ## breaks by '"'
-        x[! x %in% c("," , "")]                                 ## and drops spurious seps
+        x <- clean.spaces( strsplit(x, split = '\", ?\"')[[1]] )    ## breaks by \", \" (with or without space)
+
     }
 
 


### PR DESCRIPTION
Modify the split character in break.clean() to fix #3 .

Currently split is done with "-character. That leaves extra levels which are dropped. Dropping extra levels drops also blank levels, which leads to an error. Changing the splitting character to ", " (with or without space) does splitting without extra levels to drop. 