### PR TITLE
Added a text argument to read.px to allow parsing a PX file from text

### DIFF
--- a/R/read.px.R
+++ b/R/read.px.R
@@ -31,7 +31,14 @@
 #################################################################
 
 read.px <- function(filename, encoding = NULL, 
-                    na.strings = c('"."', '".."', '"..."', '"...."', '"....."', '"......"', '":"')) {
+                    na.strings = c('"."', '".."', '"..."', '"...."', '"....."', '"......"', '":"'),
+                    text) {
+
+    if (missing(filename) && !missing(text)) {
+        filename <- textConnection(text, encoding = "UTF-8")
+        encoding <- "UTF-8"
+        on.exit(close(filename))
+    }
 
     ## auxiliary functions ##
 
@@ -61,7 +68,7 @@ read.px <- function(filename, encoding = NULL,
                            "latin1", "CP437")  # comprobado en debian y osx
     }
 
-    a <- scan(filename, what = "character", sep = "\n", quiet = TRUE, fileEncoding = encoding)
+    a <- scan(filename, what = "character", sep = "\n", quiet = TRUE, encoding = encoding, fileEncoding = encoding)
 
     # modification by  fvf: 130608 
     a <- paste(a, collapse = "\n")        # Se mantienen "CR/LF luego se quitaran selectivamente


### PR DESCRIPTION
The native `read.table` function, of which `read.csv` etc. are based, offer a `text` parameter where you can submit the file as text. This is convenient when e.g. reading a downloaded file directly. By adding this argument, `read.px` implements an interface closer to the ones of built in file readers in R.

With this change, reading a file from the web can be done like this:

```r
req <- GET("http://www.example.com/file.px")
px_raw <- content(req, "text")
px <- read.px(text = px_raw)
```
