### PR TITLE
Update handling of 'to_values' in as.data.frame.px function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,3 +13,4 @@ Depends: stringr, reshape2, RJSONIO, plyr
 URL: https://github.com/cjgb/pxR
 License: GPL-3
 LazyLoad: yes
+RoxygenNote: 7.3.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -14,6 +14,7 @@ export(as.px)
 export(as.px.array)
 export(as.px.data.frame)
 export(write.json.stat)
+export(as.data.frame.px)
 
 S3method(as.data.frame, px)
 S3method(as.array, px)

--- a/R/as.data.frame.px.R
+++ b/R/as.data.frame.px.R
@@ -14,6 +14,7 @@
 #    20240311. munoztd0: updated the handling of 'to_values' in the mapvalues function for language translation
 #################################################################
 
+#' @export
 as.data.frame.px <- function( x, ..., use.codes = FALSE, warnings.as.errors = TRUE, direction = "long", language=FALSE){
   
   dat <- x$DATA$value  # already a data frame

--- a/R/as.data.frame.px.R
+++ b/R/as.data.frame.px.R
@@ -11,11 +11,44 @@
 #    20120402, cjgb: warnings can be either errors or warnings depending on paranoia level
 #    20120402, cjgb: adapted to the new px object format (where DATA is already a df)
 #    20141222. fvf:  bug in "wide" direction
+#    20240311. munoztd0: updated the handling of 'to_values' in the mapvalues function for language translation
 #################################################################
 
-as.data.frame.px <- function( x, ..., use.codes = FALSE, warnings.as.errors = TRUE, direction = "long"){
-
+as.data.frame.px <- function( x, ..., use.codes = FALSE, warnings.as.errors = TRUE, direction = "long", language=FALSE){
+  
   dat <- x$DATA$value  # already a data frame
+  
+  if ((!is.logical(language) && is.character(language))){
+    if(language %in% strsplit(x$LANGUAGES$value, "\",\"")[[1]]){
+      use.language = paste0('.',language,'.')
+      default.language = x$LANGUAGE
+      codes.ids = match(names(x$CODES), colnames(dat))
+      
+      for(code_id in codes.ids) {
+        if (is.na(code_id)) {
+          next
+        }
+        from_values = x$VALUES[[code_id]]
+        to_values = strsplit(x[[paste0('VALUES', use.language)]][[code_id]], "\",\"|\", \"")[[1]]
+
+        if (length(from_values) != length(to_values)) {
+          stop(paste0('The from and to vectors for code_id ', code_id, ' are not the same length.'))
+        }
+
+        dat[[codes.ids[code_id]]] <- mapvalues(dat[[codes.ids[code_id]]], 
+                                               from = from_values, 
+                                               to   = to_values)
+      }
+      translated_colnames = names(x[[paste0('CODES', use.language)]])[codes.ids]
+      translated_colnames = c(translated_colnames, 'value')
+      colnames(dat) = translated_colnames
+      
+    } else {
+      stop(paste0('Can\'t find the proposed language. Please choose one of the available languages: ', x$LANGUAGES$value))
+    }
+  } else {
+    language = ''
+  }
   
   ## maybe we need to change values to codes
   if (is.logical(use.codes) && use.codes)
@@ -23,16 +56,13 @@ as.data.frame.px <- function( x, ..., use.codes = FALSE, warnings.as.errors = TR
   
   if (! is.logical(use.codes))
     for( var.name in intersect( use.codes, intersect(colnames(dat), names(x$CODES) ) ) )
-        dat[[var.name]] <- mapvalues(dat[[var.name]], 
-                                     from = x$VALUES[[var.name]], 
-                                     to   = x$CODES[[var.name]])
-     
+      dat[[var.name]] <- mapvalues(dat[[var.name]], 
+                                   from = x$VALUES[[var.name]], 
+                                   to   = x$CODES[[var.name]])
+  
   ## do we need to reshape?
   if (direction == "wide")
-    # fvf.20121222: The order of variables rows and pivots-columns was inverted
-    # dcast(dat, list(x$HEADING$value, x$STUB$value))
     dcast(dat, list(x$STUB$value,x$HEADING$value))
   else
     dat
 }
-


### PR DESCRIPTION
This pull request includes updates to the as.data.frame.px function to improve its robustness and ability to handle a wider range of inputs.

Changes made:

- Updated the handling of 'to_values' in the mapvalues function. Now, 'to_values' is created by splitting the string x[[paste0('VALUES', use.language)]][[code_id]] at every occurrence of ", " and ",". This change was made to handle cases where x[[paste0('VALUES', use.language)]][[code_id]] is a single string that needs to be split into a vector of values.

- Added a check to ensure that the 'from_values' and 'to_values' vectors are of the same length before they are used in the mapvalues function. If they are not of the same length, the function stops with an error message. This check was added to prevent errors in the mapvalues function.

These changes make the function more robust and capable of handling a wider range of inputs. Please review the changes and merge if everything looks good.